### PR TITLE
Fix Google OAuth

### DIFF
--- a/airflow_login/airflow_auth.py
+++ b/airflow_login/airflow_auth.py
@@ -19,7 +19,7 @@ class OAuthSignIn(object):
     def callback(self):
         pass
 
-    def get_callback_url(self, scheme='http'):
+    def get_callback_url(self, scheme='https'):
         return url_for('auth_login.oauth_callback', provider=self.provider_name,
                         _external=True, _scheme=scheme)
 


### PR DESCRIPTION
Fixes https://github.com/heroku/heroku-airflow/issues/6 - the callback URL was using HTTP instead of HTTPS by default which was causing OAuth to fail.
